### PR TITLE
fix(windows): switch build to VS16 (windows-2019) to match php.net builds

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -34,7 +34,7 @@ jobs:
           
           # Windows x64 - PHP8.0
           - build: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2019
             target: x86_64-pc-windows-msvc
             php-versions: '8.0'
 
@@ -57,7 +57,7 @@ jobs:
           
           # Windows x64 - PHP8.1
           - build: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2019
             target: x86_64-pc-windows-msvc
             php-versions: '8.1'
             
@@ -80,7 +80,7 @@ jobs:
           
           # Windows x64 - PHP8.2
           - build: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2019
             target: x86_64-pc-windows-msvc
             php-versions: '8.2'
 
@@ -103,7 +103,7 @@ jobs:
           
           # Windows x64 - PHP8.3
           - build: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2019
             target: x86_64-pc-windows-msvc
             php-versions: '8.3'
           


### PR DESCRIPTION
The official PHP builds for windows from php.net use `windows-2019` (VS16). That's why windows users see the following mismatch error when trying to load the module:

```
Warning: PHP Startup: Can't load module 'php_libsql.dll' as it's linked with 14.40, but the core is linked with 14.29 in Unknown on line 0
```

Here's a link to the github action windows config the official PHP Interpreter uses: https://github.com/php/php-src/blob/93c3ebd209f2111f986a0db4c7b6ddb7284fd71c/.github/workflows/nightly.yml#L886

This PR updates this project's github action to match the PHP interpreter project

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/darkterminal/libsql-extension/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
